### PR TITLE
Fix minor bug in dispatchEvent

### DIFF
--- a/EventSource.js
+++ b/EventSource.js
@@ -120,7 +120,7 @@ EventSource.prototype = {
     var handlers = this['_' + type + 'Handlers'];
     if (handlers) {
       for (var i = 0; i < handlers.length; i++) {
-        handlers.call(this, event);
+        handlers[i].call(this, event);
       }      
     }
     


### PR DESCRIPTION
Was not properly calling the handler functions.

Tested in Firefox 5.0.1 and 3.6.20.
