### PR TITLE
Remove may remove the last class

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -38,6 +38,9 @@ DOMTokenList.prototype = {
   },
   remove: function(token) {
     var i = indexOf.call(this, token);
+     if (i === -1) {
+       return;
+     }
     splice.call(this, i, 1);
     setToClassName(this._element, slice.call(this, 0));
   },


### PR DESCRIPTION
Due to not checking the value returned by indexOf, the code removed the last class when it did not find the given class to remove.
