### PR TITLE
Fix classList property detection for IE8

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -1,6 +1,6 @@
 (function () {
 
-if (typeof Element === "undefined" || document.documentElement.hasOwnProperty("classList")) return;
+if (typeof Element === "undefined" || "classList" in document.documentElement) return;
 
 var indexOf = [].indexOf,
     slice = [].slice,


### PR DESCRIPTION
I might be going crazy, but it looks like the documentElement doesn't have a "hasOwnProperty" method in IE8.
