### PR TITLE
Two bugfixes to classList shim

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -13,7 +13,9 @@ function DOMTokenList(el) {
   if (el.className != this.classCache) {
     this._classCache = el.className;
     
-    var classes = this._classCache.split(' '),
+      // The className needs to be trimmed and split on whitespace
+      // to retrieve a list of classes.
+      var classes = this._classCache.replace(/^\s+|\s+$/g,'').split(/\s+/),
         i;
     for (i = 0; i < classes.length; i++) {
       push.call(this, classes[i]);


### PR DESCRIPTION
Hey, I found two problems. 
1. Found a problem where if you try and add a class name to an element where that class already exists then you wind up with a scenario with multiple classes.
2. Since a className could have leading and trailing whitespace or multiple spaces between classes the class list is parsed incorrectly (ie for the case className= " foo    bar baz").

Should be fixed with this PR.
