### PR TITLE
Fixed some incompatibilities and optimized the classList polyfill

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -2,16 +2,19 @@
 
 if (typeof window.Element === "undefined" || "classList" in document.documentElement) return;
 
-var indexOf = [].indexOf,
-    slice = [].slice,
-    push = [].push,
-    splice = [].splice,
-    join = [].join;
+var prototype = Array.prototype,
+    indexOf = prototype.indexOf,
+    slice = prototype.slice,
+    push = prototype.push,
+    splice = prototype.splice,
+    join = prototype.join;
 
 function DOMTokenList(el) {  
   this._element = el;
   if (el.className != this._classCache) {
     this._classCache = el.className;
+
+    if (!this._classCache) return;
     
       // The className needs to be trimmed and split on whitespace
       // to retrieve a list of classes.


### PR DESCRIPTION
Fixes -
- Any classList modification of an element with no className would prepend a whitespace to the beginning of the className.

Optimization -
- Cached Array.prototype instead of creating a new array literal for every method needed.
