### PR TITLE
Fails to install with Bower due to no version number in component.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+    "name": "html5-polyfills",
+    "description": "Collection of polyfills by Remy Sharp",
+    "homepage": "https://github.com/remy/polyfills",
+    "keywords": [
+        "polyfill",
+        "client",
+        "browser"
+    ],
+    "author": {
+        "name": "Remy Sharp",
+        "email": "remy@leftlogic.com"
+    },
+    "version": "0.0.20130621",
+    "readme": "This is my own collection of code snippets that support different native features of browsers using JavaScript (and if required, Flash in some cases).",
+    "readmeFilename": "README.md",
+    "_id": "html5-polyfills@0.0.20130621",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/remy/polyfills.git"
+    }
+}


### PR DESCRIPTION
I wanted to be able to install with Bower, so I added this bower.json, using the name in the Bower registry, `html5-polyfills`, attributed to Remy, and used the date of the last commit to master as the basis for the version number, `0.0.20130621`.
