### PR TITLE
Adds Array.prototype.indexOf polyfill

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -2,6 +2,16 @@
 
 if (typeof window.Element === "undefined" || "classList" in document.documentElement) return;
 
+// adds indexOf to Array prototype for IE support
+if (!Array.prototype.indexOf) {
+    Array.prototype.indexOf = function(obj, start) {
+        for (var i = (start || 0), j = this.length; i < j; i++) {
+            if (this[i] === obj) { return i; }
+        }
+        return -1;
+    }
+}
+
 var prototype = Array.prototype,
     indexOf = prototype.indexOf,
     slice = prototype.slice,


### PR DESCRIPTION
Array.prototype.indexOf is not supported in IE8-. This commit adds a polyfill for Array.prototype.indexOf so that classList.contains doesn't fail in IE.
