### PR TITLE
Added support for `Object.defineProperty` to dataset polyfill.

### DIFF
--- a/dataset.js
+++ b/dataset.js
@@ -1,5 +1,5 @@
-(function () {  
-  var forEach = [].forEach, 
+(function () {
+  var forEach = [].forEach,
       regex = /^data-(.+)/,
       dashChar = /\-([a-z])/ig,
       el = document.createElement('div'),
@@ -11,18 +11,18 @@
     mutationSupported = true;
     this.removeEventListener('DOMAttrModified', detectMutation, false);
   }
-  
+
   function toCamelCase(s) {
     return s.replace(dashChar, function (m,l) { return l.toUpperCase(); });
   }
-  
+
   function updateDataset() {
     var dataset = {};
     forEach.call(this.attributes, function(attr) {
       if (match = attr.name.match(regex))
         dataset[toCamelCase(match[1])] = attr.value;
     });
-    return dataset;    
+    return dataset;
   }
 
   // only add support if the browser doesn't support data-* natively
@@ -31,7 +31,17 @@
   el.addEventListener('DOMAttrModified', detectMutation, false);
   el.setAttribute('foo', 'bar');
 
-  Element.prototype.__defineGetter__('dataset', mutationSupported
+  function defineElementGetter (obj, prop, getter) {
+    if (Object.defineProperty) {
+        Object.defineProperty(obj, prop,{
+            get : getter
+        });
+    } else {
+        obj.__defineGetter__(prop, getter);
+    }
+  }
+
+  defineElementGetter(Element.prototype, 'dataset', mutationSupported
     ? function () {
       if (!this._datasetCache) {
         this._datasetCache = updateDataset.call(this);


### PR DESCRIPTION
The dataset polyfill was dependent upon `__defineGetter__` which is not supported in IE9. Copied `defineElementGetter` from classList to correct.
