### PR TITLE
Update offline-events.js

### DIFF
--- a/offline-events.js
+++ b/offline-events.js
@@ -15,9 +15,14 @@ function testConnection() {
   xhr.open('HEAD', '/', false); // async=false
   try {
     xhr.send();
-    onLine = true;
+    if(xhr.status < 299){
+    	onLine = true;
+    }else{
+    	onLine = false;
+    }
+    
   } catch (e) {
-    // throws NETWORK_ERR when disconnected
+	// throws NETWORK_ERR when disconnected
     onLine = false;
   }
 
@@ -25,14 +30,13 @@ function testConnection() {
 }
 
 var onLine = true,
-    lastOnLineStatus = true;
+lastOnLineStatus = true;
 
 // note: this doesn't allow us to define a getter in Safari
 navigator.__defineGetter__("onLine", testConnection);
 testConnection();
-
 if (onLine === false) {
-  lastOnLineStatus = false;
+  //lastOnLineStatus = false;
   // trigger offline event
   triggerEvent('offline');
 }


### PR DESCRIPTION
I changed 2 points:
1 - If the connection returns for example status 404, it should indicate how offline, before it returned online.
2 -When the connection already starts offline, it used to be online because of line 39 (// lastOnLineStatus = false)